### PR TITLE
add fallback mode

### DIFF
--- a/firmware_espidf/lib/ButtonManager/ButtonManager.cpp
+++ b/firmware_espidf/lib/ButtonManager/ButtonManager.cpp
@@ -46,6 +46,7 @@ void ButtonManager::init() {
   ButtonManager::_button1->bind(Event_KeyDown, &ButtonManager::_button1_key_down);
   ButtonManager::_button1->bind(Event_KeyUp, &ButtonManager::_button1_key_up);
   ButtonManager::_button1->bind(Event_KeyPress, &ButtonManager::_button1_press);
+  ButtonManager::_button1->bind(Event_LongKeyPress, &ButtonManager::_button1_longpress);
 
   // Init button2
   if (ButtonManager::_button2 != nullptr) {
@@ -56,6 +57,8 @@ void ButtonManager::init() {
   ButtonManager::_button2->bind(Event_KeyDown, &ButtonManager::_button2_key_down);
   ButtonManager::_button2->bind(Event_KeyUp, &ButtonManager::_button2_key_up);
   ButtonManager::_button2->bind(Event_KeyPress, &ButtonManager::_button2_press);
+  ButtonManager::_button2->bind(Event_LongKeyPress, &ButtonManager::_button2_longpress);
+
 
   InterruptButton::setMenuCount(0);
   InterruptButton::setMenuLevel(0);
@@ -165,6 +168,57 @@ void ButtonManager::_button2_press(void) {
       ESP_LOGE("ButtonManager", "Failed to get config while trying to process button press event and as such could not sent event to manager for further handling.");
     }
 
+    break;
+  }
+
+  case NSPanelConfig__NSPanelButtonMode::NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__FOLLOW:
+    break; // Simply do nothing, this is handled in "key down" and "key up" events.
+
+  default:
+    ESP_LOGE("ButtonManager", "Unknown button action. Will not perform any action.");
+    break;
+  }
+}
+
+
+void ButtonManager::_button1_longpress(void) {
+  ESP_LOGW("ButtonManager", "button1 longpress");
+  ButtonManager::_button_longpress(ButtonManager::_button1_long_mode, 1);
+}
+
+void ButtonManager::_button2_longpress(void) {
+  ESP_LOGW("ButtonManager", "button2 longpress");
+  ButtonManager::_button_longpress(ButtonManager::_button2_long_mode, 2);
+}
+
+void ButtonManager::_button_longpress(NSPanelConfig__NSPanelButtonMode mode, int button_id) {
+  switch (mode) {
+  case NSPanelConfig__NSPanelButtonMode::NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT: {
+    ButtonManager::_set_relay_state(button_id, !ButtonManager::_get_relay_state(button_id), true); // Toggle output
+    break;
+  }
+
+  case NSPanelConfig__NSPanelButtonMode::NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__NOTIFY_MANAGER: {
+    std::shared_ptr<NSPanelConfig> config;
+    if (NSPM_ConfigManager::get_config(&config) == ESP_OK) [[likely]] {
+      NSPanelMQTTManagerCommand command = NSPANEL_MQTTMANAGER_COMMAND__INIT;
+      NSPanelMQTTManagerCommand__ButtonPressed pressed_command = NSPANEL_MQTTMANAGER_COMMAND__BUTTON_LONG_PRESSED__INIT;
+      pressed_command.button_id = button_id;
+      command.button_pressed = &pressed_command;
+      command.nspanel_id = config->nspanel_id;
+      command.command_data_case = NSPANEL_MQTTMANAGER_COMMAND__COMMAND_DATA_BUTTON_LONGPRESSED;
+
+      uint32_t packed_length = nspanel_mqttmanager_command__get_packed_size(&command);
+      std::vector<uint8_t> buffer(packed_length); // Use vector for automatic cleanup of data when going out of scope
+      size_t packed_data_size = nspanel_mqttmanager_command__pack(&command, buffer.data());
+      if (packed_data_size == packed_length) [[likely]] {
+        if (MqttManager::publish(NSPM_ConfigManager::get_manager_command_topic(), (const char *)buffer.data(), packed_length, false) != ESP_OK) [[unlikely]] {
+          ESP_LOGE("ButtonManager", "Failed to publish command that button was pressed.");
+        }
+      }
+    } else {
+      ESP_LOGE("ButtonManager", "Failed to get config while trying to process button press event and as such could not sent event to manager for further handling.");
+    }
     break;
   }
 
@@ -370,6 +424,8 @@ void ButtonManager::_nspm_configmanager_event_handler(void *arg, esp_event_base_
     ButtonManager::_reverse_relays = config->reverse_relays;
     ButtonManager::_button1_mode = config->button1_mode;
     ButtonManager::_button2_mode = config->button2_mode;
+    ButtonManager::_button1_long_mode = config->button1_long_mode;
+    ButtonManager::_button2_long_mode = config->button2_long_mode;
 
     bool save = false;
     if (config->button1_mode == NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__THERMOSTAT_HEAT || config->button1_mode == NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__THERMOSTAT_COOL) {

--- a/firmware_espidf/lib/ButtonManager/ButtonManager.cpp
+++ b/firmware_espidf/lib/ButtonManager/ButtonManager.cpp
@@ -21,6 +21,11 @@ void ButtonManager::init() {
   ButtonManager::_relay2_default_mode = ConfigManager::relay2_default_mode;
   ButtonManager::_min_button_push_time = ConfigManager::min_button_push_time;
   ButtonManager::_min_button_long_push_time = ConfigManager::min_button_long_push_time;
+  ButtonManager::_button1_fallback_mode = static_cast<NSPanelConfig__NSPanelButtonFallbackMode>(ConfigManager::button1_fallback_mode);
+  ButtonManager::_button2_fallback_mode = static_cast<NSPanelConfig__NSPanelButtonFallbackMode>(ConfigManager::button2_fallback_mode);
+  ButtonManager::_button1_long_fallback_mode = static_cast<NSPanelConfig__NSPanelButtonFallbackMode>(ConfigManager::button1_long_fallback_mode);
+  ButtonManager::_button2_long_fallback_mode = static_cast<NSPanelConfig__NSPanelButtonFallbackMode>(ConfigManager::button2_long_fallback_mode);
+
 
   esp_event_handler_register(NSPM_CONFIGMANAGER_EVENT, nspm_configmanager_event::CONFIG_LOADED, ButtonManager::_nspm_configmanager_event_handler, NULL);
   esp_event_handler_register(STATUSUPDATEMANAGER_EVENT, statusupdatemanagerevent_t::AVERAGE_TEMP_UPDATE, ButtonManager::_new_temperature_event, NULL);
@@ -121,8 +126,12 @@ void ButtonManager::_button1_press(void) {
       size_t packed_data_size = nspanel_mqttmanager_command__pack(&command, buffer.data());
       if (packed_data_size == packed_length) [[likely]] {
         if (MqttManager::publish(NSPM_ConfigManager::get_manager_command_topic(), (const char *)buffer.data(), packed_length, false) != ESP_OK) [[unlikely]] {
-          ESP_LOGE("ButtonManager", "Failed to publish command that button was pressed.");
-        }
+          if (ButtonManager::_button1_fallback_mode == 0){
+            ESP_LOGE("ButtonManager", "Failed to publish command that button1 was pressed.");
+          } else{
+            ESP_LOGE("ButtonManager", "Failed to publish command that button1 was pressed. Fallback toggle relay");
+            ButtonManager::_set_relay_state(ButtonManager::_button1_fallback_mode, !ButtonManager::_get_relay_state(ButtonManager::_button1_fallback_mode), true); // Toggle output
+          }        }
       }
     } else {
       ESP_LOGE("ButtonManager", "Failed to get config while trying to process button press event and as such could not sent event to manager for further handling.");
@@ -161,7 +170,12 @@ void ButtonManager::_button2_press(void) {
       size_t packed_data_size = nspanel_mqttmanager_command__pack(&command, buffer.data());
       if (packed_data_size == packed_length) [[likely]] {
         if (MqttManager::publish(NSPM_ConfigManager::get_manager_command_topic(), (const char *)buffer.data(), packed_length, false) != ESP_OK) [[unlikely]] {
-          ESP_LOGE("ButtonManager", "Failed to publish command that button was pressed.");
+          if (ButtonManager::_button2_fallback_mode == 0){
+            ESP_LOGE("ButtonManager", "Failed to publish command that button2 was pressed.");
+          } else{
+            ESP_LOGE("ButtonManager", "Failed to publish command that button2 was pressed. Fallback toggle relay");
+            ButtonManager::_set_relay_state(ButtonManager::_button2_fallback_mode, !ButtonManager::_get_relay_state(ButtonManager::_button2_fallback_mode), true); // Toggle output
+          }
         }
       }
     } else {
@@ -183,15 +197,15 @@ void ButtonManager::_button2_press(void) {
 
 void ButtonManager::_button1_longpress(void) {
   ESP_LOGW("ButtonManager", "button1 longpress");
-  ButtonManager::_button_longpress(ButtonManager::_button1_long_mode, 1);
+  ButtonManager::_button_longpress(ButtonManager::_button1_long_mode, 1, ButtonManager::_button2_long_fallback_mode);
 }
 
 void ButtonManager::_button2_longpress(void) {
   ESP_LOGW("ButtonManager", "button2 longpress");
-  ButtonManager::_button_longpress(ButtonManager::_button2_long_mode, 2);
+  ButtonManager::_button_longpress(ButtonManager::_button2_long_mode, 2, ButtonManager::_button2_long_fallback_mode);
 }
 
-void ButtonManager::_button_longpress(NSPanelConfig__NSPanelButtonMode mode, int button_id) {
+void ButtonManager::_button_longpress(NSPanelConfig__NSPanelButtonMode mode, int button_id, int fallback_mode) {
   switch (mode) {
   case NSPanelConfig__NSPanelButtonMode::NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT: {
     ButtonManager::_set_relay_state(button_id, !ButtonManager::_get_relay_state(button_id), true); // Toggle output
@@ -213,7 +227,12 @@ void ButtonManager::_button_longpress(NSPanelConfig__NSPanelButtonMode mode, int
       size_t packed_data_size = nspanel_mqttmanager_command__pack(&command, buffer.data());
       if (packed_data_size == packed_length) [[likely]] {
         if (MqttManager::publish(NSPM_ConfigManager::get_manager_command_topic(), (const char *)buffer.data(), packed_length, false) != ESP_OK) [[unlikely]] {
-          ESP_LOGE("ButtonManager", "Failed to publish command that button was pressed.");
+          if (fallback_mode == 0){
+            ESP_LOGE("ButtonManager", "Failed to publish command that button was long pressed.");
+          } else{
+            ESP_LOGE("ButtonManager", "Failed to publish command that button was long pressed. Fallback toggle relay");
+            ButtonManager::_set_relay_state(fallback_mode, !ButtonManager::_get_relay_state(fallback_mode), true); // Toggle output
+          }
         }
       }
     } else {
@@ -505,6 +524,34 @@ void ButtonManager::_nspm_configmanager_event_handler(void *arg, esp_event_base_
 
       ButtonManager::_button1->setLongPressInterval(ButtonManager::_min_button_long_push_time);
       ButtonManager::_button2->setLongPressInterval(ButtonManager::_min_button_long_push_time);
+      save = true;
+    }
+
+    if (config->button1_fallback_mode != ButtonManager::_button1_fallback_mode) {
+      ButtonManager::_button1_fallback_mode = config->button1_fallback_mode;
+      ConfigManager::button1_fallback_mode = ButtonManager::_button1_fallback_mode;
+
+      save = true;
+    }
+
+    if (config->button2_fallback_mode != ButtonManager::_button2_fallback_mode) {
+      ButtonManager::_button2_fallback_mode = config->button2_fallback_mode;
+      ConfigManager::button2_fallback_mode = ButtonManager::_button2_fallback_mode;
+
+      save = true;
+    }
+
+    if (config->button1_long_fallback_mode != ButtonManager::_button1_long_fallback_mode) {
+      ButtonManager::_button1_long_fallback_mode = config->button1_long_fallback_mode;
+      ConfigManager::button1_long_fallback_mode = ButtonManager::_button1_long_fallback_mode;
+
+      save = true;
+    }
+
+    if (config->button2_long_fallback_mode != ButtonManager::_button2_long_fallback_mode) {
+      ButtonManager::_button2_long_fallback_mode = config->button2_long_fallback_mode;
+      ConfigManager::button2_long_fallback_mode = ButtonManager::_button2_long_fallback_mode;
+
       save = true;
     }
 

--- a/firmware_espidf/lib/ButtonManager/ButtonManager.hpp
+++ b/firmware_espidf/lib/ButtonManager/ButtonManager.hpp
@@ -49,6 +49,22 @@ private:
   static void _button2_press(void);
 
   /**
+   * Handle longpress event of button1. This is triggered on release of button.
+   */
+  static void _button1_longpress(void);
+
+  /**
+   * Handle longpress event of button2. This is triggered on release of button.
+   */
+  static void _button2_longpress(void);
+
+
+  /** 
+   * actual handler for longpress. could be reused for other button events
+   */
+  static void _button_longpress(NSPanelConfig__NSPanelButtonMode mode, int button_id);
+
+  /**
    * Set the state of a relay and send state update to MQTT
    */
   static void _set_relay_state(uint8_t relay, bool state, bool send_mqtt_update);
@@ -86,6 +102,9 @@ private:
   static inline std::atomic<bool> _relay2_current_state = false;
   static inline NSPanelConfig__NSPanelButtonMode _button1_mode = NSPanelConfig__NSPanelButtonMode::NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT; // Start by using default direct mode
   static inline NSPanelConfig__NSPanelButtonMode _button2_mode = NSPanelConfig__NSPanelButtonMode::NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT; // Start by using default direct mode;
+  static inline NSPanelConfig__NSPanelButtonMode _button1_long_mode = NSPanelConfig__NSPanelButtonMode::NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT; // Start by using default direct mode
+  static inline NSPanelConfig__NSPanelButtonMode _button2_long_mode = NSPanelConfig__NSPanelButtonMode::NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT; // Start by using default direct mode;
+
 
   // Queue of interrupt events to handle
   static inline QueueHandle_t _interrupt_queue;

--- a/firmware_espidf/lib/ButtonManager/ButtonManager.hpp
+++ b/firmware_espidf/lib/ButtonManager/ButtonManager.hpp
@@ -62,7 +62,7 @@ private:
   /** 
    * actual handler for longpress. could be reused for other button events
    */
-  static void _button_longpress(NSPanelConfig__NSPanelButtonMode mode, int button_id);
+  static void _button_longpress(NSPanelConfig__NSPanelButtonMode mode, int button_id, int fallback_mode);
 
   /**
    * Set the state of a relay and send state update to MQTT
@@ -101,9 +101,13 @@ private:
   static inline std::atomic<bool> _relay1_current_state = false;
   static inline std::atomic<bool> _relay2_current_state = false;
   static inline NSPanelConfig__NSPanelButtonMode _button1_mode = NSPanelConfig__NSPanelButtonMode::NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT; // Start by using default direct mode
+  static inline NSPanelConfig__NSPanelButtonFallbackMode _button1_fallback_mode = NSPanelConfig__NSPanelButtonFallbackMode::NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__DISABLED; // Start by using fallback disabled
   static inline NSPanelConfig__NSPanelButtonMode _button2_mode = NSPanelConfig__NSPanelButtonMode::NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT; // Start by using default direct mode;
+  static inline NSPanelConfig__NSPanelButtonFallbackMode _button2_fallback_mode = NSPanelConfig__NSPanelButtonFallbackMode::NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__DISABLED; // Start by using fallback disabled
   static inline NSPanelConfig__NSPanelButtonMode _button1_long_mode = NSPanelConfig__NSPanelButtonMode::NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT; // Start by using default direct mode
+  static inline NSPanelConfig__NSPanelButtonFallbackMode _button1_long_fallback_mode = NSPanelConfig__NSPanelButtonFallbackMode::NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__DISABLED; // Start by using fallback disabled
   static inline NSPanelConfig__NSPanelButtonMode _button2_long_mode = NSPanelConfig__NSPanelButtonMode::NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT; // Start by using default direct mode;
+  static inline NSPanelConfig__NSPanelButtonFallbackMode _button2_long_fallback_mode = NSPanelConfig__NSPanelButtonFallbackMode::NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__DISABLED; // Start by using fallback disabled
 
 
   // Queue of interrupt events to handle

--- a/firmware_espidf/lib/ConfigManager/ConfigManager.cpp
+++ b/firmware_espidf/lib/ConfigManager/ConfigManager.cpp
@@ -173,6 +173,26 @@ esp_err_t ConfigManager::load_config() {
     ConfigManager::relay2_upper_temperature = item->valueint;
   }
 
+  item = cJSON_GetObjectItem(json, "button1_fallback_mode");
+  if (cJSON_IsNumber(item)) {
+    ConfigManager::button1_fallback_mode = item->valueint;
+  }
+
+  item = cJSON_GetObjectItem(json, "button2_fallback_mode");
+  if (cJSON_IsNumber(item)) {
+    ConfigManager::button2_fallback_mode = item->valueint;
+  }
+
+    item = cJSON_GetObjectItem(json, "button1_long_fallback_mode");
+  if (cJSON_IsNumber(item)) {
+    ConfigManager::button1_long_fallback_mode = item->valueint;
+  }
+
+  item = cJSON_GetObjectItem(json, "button2_long_fallback_mode");
+  if (cJSON_IsNumber(item)) {
+    ConfigManager::button2_long_fallback_mode = item->valueint;
+  }
+
   cJSON_Delete(json);
   free(read_buffer);
 
@@ -206,6 +226,11 @@ void ConfigManager::create_default() {
   ConfigManager::nextion_upload_baudrate = 115200;
   ConfigManager::communication_baud_rate = 115200;
   ConfigManager::log_level = ESP_LOG_WARN;
+
+  ConfigManager::button1_fallback_mode=0;
+  ConfigManager::button2_fallback_mode=0;
+  ConfigManager::button1_long_fallback_mode=0;
+  ConfigManager::button2_long_fallback_mode=0;
 }
 
 esp_err_t ConfigManager::save_config() {
@@ -238,6 +263,10 @@ esp_err_t ConfigManager::save_config() {
   cJSON_AddNumberToObject(json, "relay1_upper_temperature", ConfigManager::relay1_upper_temperature);
   cJSON_AddNumberToObject(json, "relay2_lower_temperature", ConfigManager::relay2_lower_temperature);
   cJSON_AddNumberToObject(json, "relay2_upper_temperature", ConfigManager::relay2_upper_temperature);
+  cJSON_AddNumberToObject(json, "button1_fallback_mode", ConfigManager::button1_fallback_mode);
+  cJSON_AddNumberToObject(json, "button2_fallback_mode", ConfigManager::button2_fallback_mode);
+  cJSON_AddNumberToObject(json, "button1_long_fallback_mode", ConfigManager::button1_long_fallback_mode);
+  cJSON_AddNumberToObject(json, "button2_long_fallback_mode", ConfigManager::button2_long_fallback_mode);
 
   if (ConfigManager::use_latest_nextion_upload_protocol) {
     cJSON_AddTrueToObject(json, "use_new_upload_protocol");

--- a/firmware_espidf/lib/ConfigManager/ConfigManager.hpp
+++ b/firmware_espidf/lib/ConfigManager/ConfigManager.hpp
@@ -108,4 +108,10 @@ public:
 
   // Number of boots that latest less then 3 seconds. Used to reset panel when turning it off/on/off many times in a row.
   static inline uint8_t num_failed_boots = 0;
+
+  // fallback mode of all button_press actions  
+  static inline uint8_t button1_fallback_mode=0;
+  static inline uint8_t button2_fallback_mode=0;
+  static inline uint8_t button1_long_fallback_mode=0;
+  static inline uint8_t button2_long_fallback_mode=0;
 };

--- a/firmware_espidf/lib/MqttManager/MqttManager.cpp
+++ b/firmware_espidf/lib/MqttManager/MqttManager.cpp
@@ -4,6 +4,7 @@
 #include <WiFiManager.hpp>
 #include <cJSON.h>
 #include <esp_log.h>
+#include <NSPM_version.hpp>
 
 void MqttManager::start(std::string *server, uint16_t *port, std::string *username, std::string *password) {
   esp_log_level_set("MqttManager", ConfigManager::log_level);
@@ -142,6 +143,7 @@ void MqttManager::_send_mqtt_online_update() {
     if (json != NULL) {
       cJSON_AddStringToObject(json, "mac", WiFiManager::mac_string());
       cJSON_AddStringToObject(json, "state", "online");
+      cJSON_AddStringToObject(json, "version", NSPM_VERSION);
     } else {
       ESP_LOGE("MqttManager", "Failed to create cJSON object when trying to send online state update!");
       return;

--- a/firmware_espidf/lib/NSPM_Version/NSPM_version.hpp
+++ b/firmware_espidf/lib/NSPM_Version/NSPM_version.hpp
@@ -1,1 +1,1 @@
-#define NSPM_VERSION "0.3.784"
+#define NSPM_VERSION "0.3.804"

--- a/firmware_espidf/lib/ProtoBuf/protobuf_nspanel.pb-c.c
+++ b/firmware_espidf/lib/ProtoBuf/protobuf_nspanel.pb-c.c
@@ -376,6 +376,12 @@ void   nspanel_mqttmanager_command__button_pressed__init
   static const NSPanelMQTTManagerCommand__ButtonPressed init_value = NSPANEL_MQTTMANAGER_COMMAND__BUTTON_PRESSED__INIT;
   *message = init_value;
 }
+void   nspanel_mqttmanager_command__button_long_pressed__init
+                     (NSPanelMQTTManagerCommand__ButtonLongPressed         *message)
+{
+  static const NSPanelMQTTManagerCommand__ButtonLongPressed init_value = NSPANEL_MQTTMANAGER_COMMAND__BUTTON_LONG_PRESSED__INIT;
+  *message = init_value;
+}
 void   nspanel_mqttmanager_command__thermostat_temperature_command__init
                      (NSPanelMQTTManagerCommand__ThermostatTemperatureCommand         *message)
 {
@@ -595,7 +601,7 @@ const ProtobufCEnumDescriptor nspanel_config__nspanel_button_mode__descriptor =
   nspanel_config__nspanel_button_mode__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
-static const ProtobufCFieldDescriptor nspanel_config__field_descriptors[36] =
+static const ProtobufCFieldDescriptor nspanel_config__field_descriptors[38] =
 {
   {
     "name",
@@ -874,6 +880,30 @@ static const ProtobufCFieldDescriptor nspanel_config__field_descriptors[36] =
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
+    "button1_long_mode",
+    27,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_ENUM,
+    0,   /* quantifier_offset */
+    offsetof(NSPanelConfig, button1_long_mode),
+    &nspanel_config__nspanel_button_mode__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "button2_long_mode",
+    29,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_ENUM,
+    0,   /* quantifier_offset */
+    offsetof(NSPanelConfig, button2_long_mode),
+    &nspanel_config__nspanel_button_mode__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
     "global_scene_entity_page_ids",
     30,
     PROTOBUF_C_LABEL_REPEATED,
@@ -1031,30 +1061,32 @@ static const ProtobufCFieldDescriptor nspanel_config__field_descriptors[36] =
   },
 };
 static const unsigned nspanel_config__field_indices_by_name[] = {
-  32,   /* field[32] = button1_lower_temperature */
+  23,   /* field[23] = button1_long_mode */
+  34,   /* field[34] = button1_lower_temperature */
   21,   /* field[21] = button1_mode */
-  33,   /* field[33] = button1_upper_temperature */
-  34,   /* field[34] = button2_lower_temperature */
+  35,   /* field[35] = button1_upper_temperature */
+  24,   /* field[24] = button2_long_mode */
+  36,   /* field[36] = button2_lower_temperature */
   22,   /* field[22] = button2_mode */
-  35,   /* field[35] = button2_upper_temperature */
+  37,   /* field[37] = button2_upper_temperature */
   5,   /* field[5] = button_long_press_time */
   13,   /* field[13] = clock_us_style */
-  29,   /* field[29] = default_light_brightess */
+  31,   /* field[31] = default_light_brightess */
   2,   /* field[2] = default_page */
   1,   /* field[1] = default_room */
-  23,   /* field[23] = global_scene_entity_page_ids */
-  31,   /* field[31] = inside_temperature_sensor_mqtt_topic */
+  25,   /* field[25] = global_scene_entity_page_ids */
+  33,   /* field[33] = inside_temperature_sensor_mqtt_topic */
   15,   /* field[15] = is_us_panel */
-  30,   /* field[30] = locked_to_default_room */
+  32,   /* field[32] = locked_to_default_room */
   4,   /* field[4] = min_button_push_time */
   0,   /* field[0] = name */
-  26,   /* field[26] = nspanel_id */
-  24,   /* field[24] = optimistic_mode */
-  25,   /* field[25] = raise_light_level_to_100_above */
+  28,   /* field[28] = nspanel_id */
+  26,   /* field[26] = optimistic_mode */
+  27,   /* field[27] = raise_light_level_to_100_above */
   18,   /* field[18] = relay1_default_mode */
-  27,   /* field[27] = relay1_relay_group */
+  29,   /* field[29] = relay1_relay_group */
   19,   /* field[19] = relay2_default_mode */
-  28,   /* field[28] = relay2_relay_group */
+  30,   /* field[30] = relay2_relay_group */
   17,   /* field[17] = reverse_relays */
   16,   /* field[16] = room_infos */
   8,   /* field[8] = screen_dim_level */
@@ -1068,14 +1100,15 @@ static const unsigned nspanel_config__field_indices_by_name[] = {
   20,   /* field[20] = temperature_calibration */
   14,   /* field[14] = use_fahrenheit */
 };
-static const ProtobufCIntRange nspanel_config__number_ranges[5 + 1] =
+static const ProtobufCIntRange nspanel_config__number_ranges[6 + 1] =
 {
   { 1, 0 },
   { 25, 22 },
-  { 30, 23 },
-  { 35, 27 },
-  { 37, 28 },
-  { 0, 36 }
+  { 27, 23 },
+  { 29, 24 },
+  { 35, 29 },
+  { 37, 30 },
+  { 0, 38 }
 };
 const ProtobufCMessageDescriptor nspanel_config__descriptor =
 {
@@ -1085,10 +1118,10 @@ const ProtobufCMessageDescriptor nspanel_config__descriptor =
   "NSPanelConfig",
   "",
   sizeof(NSPanelConfig),
-  36,
+  38,
   nspanel_config__field_descriptors,
   nspanel_config__field_indices_by_name,
-  5,  nspanel_config__number_ranges,
+  6,  nspanel_config__number_ranges,
   (ProtobufCMessageInit) nspanel_config__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
@@ -1177,7 +1210,7 @@ const ProtobufCEnumDescriptor nspanel_status_report__state__descriptor =
   nspanel_status_report__state__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
-static const ProtobufCFieldDescriptor nspanel_status_report__field_descriptors[11] =
+static const ProtobufCFieldDescriptor nspanel_status_report__field_descriptors[12] =
 {
   {
     "nspanel_state",
@@ -1311,6 +1344,18 @@ static const ProtobufCFieldDescriptor nspanel_status_report__field_descriptors[1
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "version",
+    12,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(NSPanelStatusReport, version),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned nspanel_status_report__field_indices_by_name[] = {
   3,   /* field[3] = heap_used_pct */
@@ -1323,12 +1368,13 @@ static const unsigned nspanel_status_report__field_indices_by_name[] = {
   2,   /* field[2] = rssi */
   5,   /* field[5] = temperature */
   1,   /* field[1] = update_progress */
+  11,   /* field[11] = version */
   7,   /* field[7] = warnings */
 };
 static const ProtobufCIntRange nspanel_status_report__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 11 }
+  { 0, 12 }
 };
 const ProtobufCMessageDescriptor nspanel_status_report__descriptor =
 {
@@ -1338,7 +1384,7 @@ const ProtobufCMessageDescriptor nspanel_status_report__descriptor =
   "NSPanelStatusReport",
   "",
   sizeof(NSPanelStatusReport),
-  11,
+  12,
   nspanel_status_report__field_descriptors,
   nspanel_status_report__field_indices_by_name,
   1,  nspanel_status_report__number_ranges,
@@ -2555,6 +2601,44 @@ const ProtobufCMessageDescriptor nspanel_mqttmanager_command__button_pressed__de
   (ProtobufCMessageInit) nspanel_mqttmanager_command__button_pressed__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
+static const ProtobufCFieldDescriptor nspanel_mqttmanager_command__button_long_pressed__field_descriptors[1] =
+{
+  {
+    "button_id",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_INT32,
+    0,   /* quantifier_offset */
+    offsetof(NSPanelMQTTManagerCommand__ButtonLongPressed, button_id),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned nspanel_mqttmanager_command__button_long_pressed__field_indices_by_name[] = {
+  0,   /* field[0] = button_id */
+};
+static const ProtobufCIntRange nspanel_mqttmanager_command__button_long_pressed__number_ranges[1 + 1] =
+{
+  { 2, 0 },
+  { 0, 1 }
+};
+const ProtobufCMessageDescriptor nspanel_mqttmanager_command__button_long_pressed__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "NSPanelMQTTManagerCommand.ButtonLongPressed",
+  "ButtonLongPressed",
+  "NSPanelMQTTManagerCommand__ButtonLongPressed",
+  "",
+  sizeof(NSPanelMQTTManagerCommand__ButtonLongPressed),
+  1,
+  nspanel_mqttmanager_command__button_long_pressed__field_descriptors,
+  nspanel_mqttmanager_command__button_long_pressed__field_indices_by_name,
+  1,  nspanel_mqttmanager_command__button_long_pressed__number_ranges,
+  (ProtobufCMessageInit) nspanel_mqttmanager_command__button_long_pressed__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
 static const ProtobufCFieldDescriptor nspanel_mqttmanager_command__thermostat_temperature_command__field_descriptors[2] =
 {
   {
@@ -2700,7 +2784,7 @@ const ProtobufCEnumDescriptor nspanel_mqttmanager_command__affect_lights_options
   nspanel_mqttmanager_command__affect_lights_options__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
-static const ProtobufCFieldDescriptor nspanel_mqttmanager_command__field_descriptors[9] =
+static const ProtobufCFieldDescriptor nspanel_mqttmanager_command__field_descriptors[10] =
 {
   {
     "first_page_turn_on",
@@ -2775,8 +2859,20 @@ static const ProtobufCFieldDescriptor nspanel_mqttmanager_command__field_descrip
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "thermostat_temperature_command",
+    "button_longpressed",
     7,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NSPanelMQTTManagerCommand, command_data_case),
+    offsetof(NSPanelMQTTManagerCommand, button_longpressed),
+    &nspanel_mqttmanager_command__button_long_pressed__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "thermostat_temperature_command",
+    8,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NSPanelMQTTManagerCommand, command_data_case),
@@ -2788,7 +2884,7 @@ static const ProtobufCFieldDescriptor nspanel_mqttmanager_command__field_descrip
   },
   {
     "thermostat_command",
-    8,
+    9,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NSPanelMQTTManagerCommand, command_data_case),
@@ -2812,21 +2908,22 @@ static const ProtobufCFieldDescriptor nspanel_mqttmanager_command__field_descrip
   },
 };
 static const unsigned nspanel_mqttmanager_command__field_indices_by_name[] = {
+  6,   /* field[6] = button_longpressed */
   5,   /* field[5] = button_pressed */
   1,   /* field[1] = first_page_turn_off */
   0,   /* field[0] = first_page_turn_on */
   2,   /* field[2] = light_command */
-  8,   /* field[8] = nspanel_id */
+  9,   /* field[9] = nspanel_id */
   4,   /* field[4] = save_scene_command */
-  7,   /* field[7] = thermostat_command */
-  6,   /* field[6] = thermostat_temperature_command */
+  8,   /* field[8] = thermostat_command */
+  7,   /* field[7] = thermostat_temperature_command */
   3,   /* field[3] = toggle_entity_from_entities_page */
 };
 static const ProtobufCIntRange nspanel_mqttmanager_command__number_ranges[2 + 1] =
 {
   { 1, 0 },
-  { 100, 8 },
-  { 0, 9 }
+  { 100, 9 },
+  { 0, 10 }
 };
 const ProtobufCMessageDescriptor nspanel_mqttmanager_command__descriptor =
 {
@@ -2836,7 +2933,7 @@ const ProtobufCMessageDescriptor nspanel_mqttmanager_command__descriptor =
   "NSPanelMQTTManagerCommand",
   "",
   sizeof(NSPanelMQTTManagerCommand),
-  9,
+  10,
   nspanel_mqttmanager_command__field_descriptors,
   nspanel_mqttmanager_command__field_indices_by_name,
   2,  nspanel_mqttmanager_command__number_ranges,

--- a/firmware_espidf/lib/ProtoBuf/protobuf_nspanel.pb-c.c
+++ b/firmware_espidf/lib/ProtoBuf/protobuf_nspanel.pb-c.c
@@ -601,7 +601,37 @@ const ProtobufCEnumDescriptor nspanel_config__nspanel_button_mode__descriptor =
   nspanel_config__nspanel_button_mode__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
-static const ProtobufCFieldDescriptor nspanel_config__field_descriptors[38] =
+static const ProtobufCEnumValue nspanel_config__nspanel_button_fallback_mode__enum_values_by_number[3] =
+{
+  { "DISABLED", "NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__DISABLED", 0 },
+  { "TOGGLE_RELAY1", "NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__TOGGLE_RELAY1", 1 },
+  { "TOGLLE_RELAY2", "NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__TOGLLE_RELAY2", 2 },
+};
+static const ProtobufCIntRange nspanel_config__nspanel_button_fallback_mode__value_ranges[] = {
+{0, 0},{0, 3}
+};
+static const ProtobufCEnumValueIndex nspanel_config__nspanel_button_fallback_mode__enum_values_by_name[3] =
+{
+  { "DISABLED", 0 },
+  { "TOGGLE_RELAY1", 1 },
+  { "TOGLLE_RELAY2", 2 },
+};
+const ProtobufCEnumDescriptor nspanel_config__nspanel_button_fallback_mode__descriptor =
+{
+  PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC,
+  "NSPanelConfig.NSPanelButtonFallbackMode",
+  "NSPanelButtonFallbackMode",
+  "NSPanelConfig__NSPanelButtonFallbackMode",
+  "",
+  3,
+  nspanel_config__nspanel_button_fallback_mode__enum_values_by_number,
+  3,
+  nspanel_config__nspanel_button_fallback_mode__enum_values_by_name,
+  1,
+  nspanel_config__nspanel_button_fallback_mode__value_ranges,
+  NULL,NULL,NULL,NULL   /* reserved[1234] */
+};
+static const ProtobufCFieldDescriptor nspanel_config__field_descriptors[42] =
 {
   {
     "name",
@@ -868,8 +898,20 @@ static const ProtobufCFieldDescriptor nspanel_config__field_descriptors[38] =
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
+    "button1_fallback_mode",
+    23,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_ENUM,
+    0,   /* quantifier_offset */
+    offsetof(NSPanelConfig, button1_fallback_mode),
+    &nspanel_config__nspanel_button_fallback_mode__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
     "button2_mode",
-    25,
+    24,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_ENUM,
     0,   /* quantifier_offset */
@@ -880,8 +922,20 @@ static const ProtobufCFieldDescriptor nspanel_config__field_descriptors[38] =
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
+    "button2_fallback_mode",
+    25,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_ENUM,
+    0,   /* quantifier_offset */
+    offsetof(NSPanelConfig, button2_fallback_mode),
+    &nspanel_config__nspanel_button_fallback_mode__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
     "button1_long_mode",
-    27,
+    26,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_ENUM,
     0,   /* quantifier_offset */
@@ -892,13 +946,37 @@ static const ProtobufCFieldDescriptor nspanel_config__field_descriptors[38] =
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
+    "button1_long_fallback_mode",
+    27,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_ENUM,
+    0,   /* quantifier_offset */
+    offsetof(NSPanelConfig, button1_long_fallback_mode),
+    &nspanel_config__nspanel_button_fallback_mode__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
     "button2_long_mode",
-    29,
+    28,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_ENUM,
     0,   /* quantifier_offset */
     offsetof(NSPanelConfig, button2_long_mode),
     &nspanel_config__nspanel_button_mode__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "button2_long_fallback_mode",
+    29,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_ENUM,
+    0,   /* quantifier_offset */
+    offsetof(NSPanelConfig, button2_long_fallback_mode),
+    &nspanel_config__nspanel_button_fallback_mode__descriptor,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
@@ -1061,32 +1139,36 @@ static const ProtobufCFieldDescriptor nspanel_config__field_descriptors[38] =
   },
 };
 static const unsigned nspanel_config__field_indices_by_name[] = {
-  23,   /* field[23] = button1_long_mode */
-  34,   /* field[34] = button1_lower_temperature */
+  22,   /* field[22] = button1_fallback_mode */
+  26,   /* field[26] = button1_long_fallback_mode */
+  25,   /* field[25] = button1_long_mode */
+  38,   /* field[38] = button1_lower_temperature */
   21,   /* field[21] = button1_mode */
-  35,   /* field[35] = button1_upper_temperature */
-  24,   /* field[24] = button2_long_mode */
-  36,   /* field[36] = button2_lower_temperature */
-  22,   /* field[22] = button2_mode */
-  37,   /* field[37] = button2_upper_temperature */
+  39,   /* field[39] = button1_upper_temperature */
+  24,   /* field[24] = button2_fallback_mode */
+  28,   /* field[28] = button2_long_fallback_mode */
+  27,   /* field[27] = button2_long_mode */
+  40,   /* field[40] = button2_lower_temperature */
+  23,   /* field[23] = button2_mode */
+  41,   /* field[41] = button2_upper_temperature */
   5,   /* field[5] = button_long_press_time */
   13,   /* field[13] = clock_us_style */
-  31,   /* field[31] = default_light_brightess */
+  35,   /* field[35] = default_light_brightess */
   2,   /* field[2] = default_page */
   1,   /* field[1] = default_room */
-  25,   /* field[25] = global_scene_entity_page_ids */
-  33,   /* field[33] = inside_temperature_sensor_mqtt_topic */
+  29,   /* field[29] = global_scene_entity_page_ids */
+  37,   /* field[37] = inside_temperature_sensor_mqtt_topic */
   15,   /* field[15] = is_us_panel */
-  32,   /* field[32] = locked_to_default_room */
+  36,   /* field[36] = locked_to_default_room */
   4,   /* field[4] = min_button_push_time */
   0,   /* field[0] = name */
-  28,   /* field[28] = nspanel_id */
-  26,   /* field[26] = optimistic_mode */
-  27,   /* field[27] = raise_light_level_to_100_above */
+  32,   /* field[32] = nspanel_id */
+  30,   /* field[30] = optimistic_mode */
+  31,   /* field[31] = raise_light_level_to_100_above */
   18,   /* field[18] = relay1_default_mode */
-  29,   /* field[29] = relay1_relay_group */
+  33,   /* field[33] = relay1_relay_group */
   19,   /* field[19] = relay2_default_mode */
-  30,   /* field[30] = relay2_relay_group */
+  34,   /* field[34] = relay2_relay_group */
   17,   /* field[17] = reverse_relays */
   16,   /* field[16] = room_infos */
   8,   /* field[8] = screen_dim_level */
@@ -1100,15 +1182,12 @@ static const unsigned nspanel_config__field_indices_by_name[] = {
   20,   /* field[20] = temperature_calibration */
   14,   /* field[14] = use_fahrenheit */
 };
-static const ProtobufCIntRange nspanel_config__number_ranges[6 + 1] =
+static const ProtobufCIntRange nspanel_config__number_ranges[3 + 1] =
 {
   { 1, 0 },
-  { 25, 22 },
-  { 27, 23 },
-  { 29, 24 },
-  { 35, 29 },
-  { 37, 30 },
-  { 0, 38 }
+  { 35, 33 },
+  { 37, 34 },
+  { 0, 42 }
 };
 const ProtobufCMessageDescriptor nspanel_config__descriptor =
 {
@@ -1118,10 +1197,10 @@ const ProtobufCMessageDescriptor nspanel_config__descriptor =
   "NSPanelConfig",
   "",
   sizeof(NSPanelConfig),
-  38,
+  42,
   nspanel_config__field_descriptors,
   nspanel_config__field_indices_by_name,
-  6,  nspanel_config__number_ranges,
+  3,  nspanel_config__number_ranges,
   (ProtobufCMessageInit) nspanel_config__init,
   NULL,NULL,NULL    /* reserved[123] */
 };

--- a/firmware_espidf/lib/ProtoBuf/protobuf_nspanel.pb-c.h
+++ b/firmware_espidf/lib/ProtoBuf/protobuf_nspanel.pb-c.h
@@ -32,6 +32,7 @@ typedef struct NSPanelMQTTManagerCommand__LightCommand NSPanelMQTTManagerCommand
 typedef struct NSPanelMQTTManagerCommand__ToggleEntityFromEntitiesPage NSPanelMQTTManagerCommand__ToggleEntityFromEntitiesPage;
 typedef struct NSPanelMQTTManagerCommand__SaveSceneCommand NSPanelMQTTManagerCommand__SaveSceneCommand;
 typedef struct NSPanelMQTTManagerCommand__ButtonPressed NSPanelMQTTManagerCommand__ButtonPressed;
+typedef struct NSPanelMQTTManagerCommand__ButtonLongPressed NSPanelMQTTManagerCommand__ButtonLongPressed;
 typedef struct NSPanelMQTTManagerCommand__ThermostatTemperatureCommand NSPanelMQTTManagerCommand__ThermostatTemperatureCommand;
 typedef struct NSPanelMQTTManagerCommand__ThermostatCommand NSPanelMQTTManagerCommand__ThermostatCommand;
 
@@ -137,6 +138,8 @@ struct  NSPanelConfig
   int32_t temperature_calibration;
   NSPanelConfig__NSPanelButtonMode button1_mode;
   NSPanelConfig__NSPanelButtonMode button2_mode;
+  NSPanelConfig__NSPanelButtonMode button1_long_mode;
+  NSPanelConfig__NSPanelButtonMode button2_long_mode;
   size_t n_global_scene_entity_page_ids;
   int32_t *global_scene_entity_page_ids;
   protobuf_c_boolean optimistic_mode;
@@ -174,7 +177,7 @@ struct  NSPanelConfig
 };
 #define NSPANEL_CONFIG__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&nspanel_config__descriptor) \
-    , (char *)protobuf_c_empty_string, 0, NSPANEL_CONFIG__NSPANEL_DEFAULT_PAGE__HOME, 0, 0, 0, 0, 0, 0, 0, NSPANEL_CONFIG__NSPANEL_SCREENSAVER_MODE__WEATHER_WITH_BACKGROUND, 0, 0, 0, 0, 0, 0,NULL, 0, 0, 0, 0, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, 0,NULL, 0, 0, 0, 0,NULL, 0,NULL, 0, 0, (char *)protobuf_c_empty_string, 0, 0, 0, 0 }
+    , (char *)protobuf_c_empty_string, 0, NSPANEL_CONFIG__NSPANEL_DEFAULT_PAGE__HOME, 0, 0, 0, 0, 0, 0, 0, NSPANEL_CONFIG__NSPANEL_SCREENSAVER_MODE__WEATHER_WITH_BACKGROUND, 0, 0, 0, 0, 0, 0,NULL, 0, 0, 0, 0, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, 0,NULL, 0, 0, 0, 0,NULL, 0,NULL, 0, 0, (char *)protobuf_c_empty_string, 0, 0, 0, 0 }
 
 
 struct  NSPanelWarning
@@ -203,10 +206,11 @@ struct  NSPanelStatusReport
   char *md5_firmware;
   char *md5_littlefs;
   char *md5_tft_gui;
+  char *version;
 };
 #define NSPANEL_STATUS_REPORT__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&nspanel_status_report__descriptor) \
-    , NSPANEL_STATUS_REPORT__STATE__ONLINE, 0, 0, 0, (char *)protobuf_c_empty_string, 0, (char *)protobuf_c_empty_string, 0,NULL, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string }
+    , NSPANEL_STATUS_REPORT__STATE__ONLINE, 0, 0, 0, (char *)protobuf_c_empty_string, 0, (char *)protobuf_c_empty_string, 0,NULL, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string }
 
 
 struct  NSPanelLightStatus
@@ -415,6 +419,16 @@ struct  NSPanelMQTTManagerCommand__ButtonPressed
     , 0 }
 
 
+struct  NSPanelMQTTManagerCommand__ButtonLongPressed
+{
+  ProtobufCMessage base;
+  int32_t button_id;
+};
+#define NSPANEL_MQTTMANAGER_COMMAND__BUTTON_LONG_PRESSED__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&nspanel_mqttmanager_command__button_long_pressed__descriptor) \
+    , 0 }
+
+
 struct  NSPanelMQTTManagerCommand__ThermostatTemperatureCommand
 {
   ProtobufCMessage base;
@@ -446,8 +460,9 @@ typedef enum {
   NSPANEL_MQTTMANAGER_COMMAND__COMMAND_DATA_TOGGLE_ENTITY_FROM_ENTITIES_PAGE = 4,
   NSPANEL_MQTTMANAGER_COMMAND__COMMAND_DATA_SAVE_SCENE_COMMAND = 5,
   NSPANEL_MQTTMANAGER_COMMAND__COMMAND_DATA_BUTTON_PRESSED = 6,
-  NSPANEL_MQTTMANAGER_COMMAND__COMMAND_DATA_THERMOSTAT_TEMPERATURE_COMMAND = 7,
-  NSPANEL_MQTTMANAGER_COMMAND__COMMAND_DATA_THERMOSTAT_COMMAND = 8
+  NSPANEL_MQTTMANAGER_COMMAND__COMMAND_DATA_BUTTON_LONGPRESSED = 7,
+  NSPANEL_MQTTMANAGER_COMMAND__COMMAND_DATA_THERMOSTAT_TEMPERATURE_COMMAND = 8,
+  NSPANEL_MQTTMANAGER_COMMAND__COMMAND_DATA_THERMOSTAT_COMMAND = 9
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(NSPANEL_MQTTMANAGER_COMMAND__COMMAND_DATA__CASE)
 } NSPanelMQTTManagerCommand__CommandDataCase;
 
@@ -466,6 +481,7 @@ struct  NSPanelMQTTManagerCommand
     NSPanelMQTTManagerCommand__ToggleEntityFromEntitiesPage *toggle_entity_from_entities_page;
     NSPanelMQTTManagerCommand__SaveSceneCommand *save_scene_command;
     NSPanelMQTTManagerCommand__ButtonPressed *button_pressed;
+    NSPanelMQTTManagerCommand__ButtonLongPressed *button_longpressed;
     NSPanelMQTTManagerCommand__ThermostatTemperatureCommand *thermostat_temperature_command;
     NSPanelMQTTManagerCommand__ThermostatCommand *thermostat_command;
   };
@@ -635,6 +651,9 @@ void   nspanel_mqttmanager_command__save_scene_command__init
 /* NSPanelMQTTManagerCommand__ButtonPressed methods */
 void   nspanel_mqttmanager_command__button_pressed__init
                      (NSPanelMQTTManagerCommand__ButtonPressed         *message);
+/* NSPanelMQTTManagerCommand__ButtonLongPressed methods */
+void   nspanel_mqttmanager_command__button_long_pressed__init
+                     (NSPanelMQTTManagerCommand__ButtonLongPressed         *message);
 /* NSPanelMQTTManagerCommand__ThermostatTemperatureCommand methods */
 void   nspanel_mqttmanager_command__thermostat_temperature_command__init
                      (NSPanelMQTTManagerCommand__ThermostatTemperatureCommand         *message);
@@ -710,6 +729,9 @@ typedef void (*NSPanelMQTTManagerCommand__SaveSceneCommand_Closure)
 typedef void (*NSPanelMQTTManagerCommand__ButtonPressed_Closure)
                  (const NSPanelMQTTManagerCommand__ButtonPressed *message,
                   void *closure_data);
+typedef void (*NSPanelMQTTManagerCommand__ButtonLongPressed_Closure)
+                 (const NSPanelMQTTManagerCommand__ButtonLongPressed *message,
+                  void *closure_data);
 typedef void (*NSPanelMQTTManagerCommand__ThermostatTemperatureCommand_Closure)
                  (const NSPanelMQTTManagerCommand__ThermostatTemperatureCommand *message,
                   void *closure_data);
@@ -747,6 +769,7 @@ extern const ProtobufCMessageDescriptor nspanel_mqttmanager_command__light_comma
 extern const ProtobufCMessageDescriptor nspanel_mqttmanager_command__toggle_entity_from_entities_page__descriptor;
 extern const ProtobufCMessageDescriptor nspanel_mqttmanager_command__save_scene_command__descriptor;
 extern const ProtobufCMessageDescriptor nspanel_mqttmanager_command__button_pressed__descriptor;
+extern const ProtobufCMessageDescriptor nspanel_mqttmanager_command__button_long_pressed__descriptor;
 extern const ProtobufCMessageDescriptor nspanel_mqttmanager_command__thermostat_temperature_command__descriptor;
 extern const ProtobufCMessageDescriptor nspanel_mqttmanager_command__thermostat_command__descriptor;
 extern const ProtobufCEnumDescriptor    nspanel_mqttmanager_command__affect_lights_options__descriptor;

--- a/firmware_espidf/lib/ProtoBuf/protobuf_nspanel.pb-c.h
+++ b/firmware_espidf/lib/ProtoBuf/protobuf_nspanel.pb-c.h
@@ -68,6 +68,12 @@ typedef enum _NSPanelConfig__NSPanelButtonMode {
   NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__THERMOSTAT_COOL = 4
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(NSPANEL_CONFIG__NSPANEL_BUTTON_MODE)
 } NSPanelConfig__NSPanelButtonMode;
+typedef enum _NSPanelConfig__NSPanelButtonFallbackMode {
+  NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__DISABLED = 0,
+  NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__TOGGLE_RELAY1 = 1,
+  NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__TOGLLE_RELAY2 = 2
+    PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE)
+} NSPanelConfig__NSPanelButtonFallbackMode;
 typedef enum _NSPanelStatusReport__State {
   NSPANEL_STATUS_REPORT__STATE__ONLINE = 0,
   NSPANEL_STATUS_REPORT__STATE__OFFLINE = 1,
@@ -137,9 +143,13 @@ struct  NSPanelConfig
   protobuf_c_boolean relay2_default_mode;
   int32_t temperature_calibration;
   NSPanelConfig__NSPanelButtonMode button1_mode;
+  NSPanelConfig__NSPanelButtonFallbackMode button1_fallback_mode;
   NSPanelConfig__NSPanelButtonMode button2_mode;
+  NSPanelConfig__NSPanelButtonFallbackMode button2_fallback_mode;
   NSPanelConfig__NSPanelButtonMode button1_long_mode;
+  NSPanelConfig__NSPanelButtonFallbackMode button1_long_fallback_mode;
   NSPanelConfig__NSPanelButtonMode button2_long_mode;
+  NSPanelConfig__NSPanelButtonFallbackMode button2_long_fallback_mode;
   size_t n_global_scene_entity_page_ids;
   int32_t *global_scene_entity_page_ids;
   protobuf_c_boolean optimistic_mode;
@@ -177,7 +187,7 @@ struct  NSPanelConfig
 };
 #define NSPANEL_CONFIG__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&nspanel_config__descriptor) \
-    , (char *)protobuf_c_empty_string, 0, NSPANEL_CONFIG__NSPANEL_DEFAULT_PAGE__HOME, 0, 0, 0, 0, 0, 0, 0, NSPANEL_CONFIG__NSPANEL_SCREENSAVER_MODE__WEATHER_WITH_BACKGROUND, 0, 0, 0, 0, 0, 0,NULL, 0, 0, 0, 0, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, 0,NULL, 0, 0, 0, 0,NULL, 0,NULL, 0, 0, (char *)protobuf_c_empty_string, 0, 0, 0, 0 }
+    , (char *)protobuf_c_empty_string, 0, NSPANEL_CONFIG__NSPANEL_DEFAULT_PAGE__HOME, 0, 0, 0, 0, 0, 0, 0, NSPANEL_CONFIG__NSPANEL_SCREENSAVER_MODE__WEATHER_WITH_BACKGROUND, 0, 0, 0, 0, 0, 0,NULL, 0, 0, 0, 0, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__DISABLED, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__DISABLED, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__DISABLED, NSPANEL_CONFIG__NSPANEL_BUTTON_MODE__DIRECT, NSPANEL_CONFIG__NSPANEL_BUTTON_FALLBACK_MODE__DISABLED, 0,NULL, 0, 0, 0, 0,NULL, 0,NULL, 0, 0, (char *)protobuf_c_empty_string, 0, 0, 0, 0 }
 
 
 struct  NSPanelWarning
@@ -753,6 +763,7 @@ extern const ProtobufCMessageDescriptor nspanel_config__room_info__descriptor;
 extern const ProtobufCEnumDescriptor    nspanel_config__nspanel_default_page__descriptor;
 extern const ProtobufCEnumDescriptor    nspanel_config__nspanel_screensaver_mode__descriptor;
 extern const ProtobufCEnumDescriptor    nspanel_config__nspanel_button_mode__descriptor;
+extern const ProtobufCEnumDescriptor    nspanel_config__nspanel_button_fallback_mode__descriptor;
 extern const ProtobufCMessageDescriptor nspanel_warning__descriptor;
 extern const ProtobufCMessageDescriptor nspanel_status_report__descriptor;
 extern const ProtobufCEnumDescriptor    nspanel_status_report__state__descriptor;

--- a/firmware_espidf/lib/StatusUpdateManager/StatusUpdateManager.cpp
+++ b/firmware_espidf/lib/StatusUpdateManager/StatusUpdateManager.cpp
@@ -6,6 +6,7 @@
 #include <StatusUpdateManager_events.hpp>
 #include <UpdateManager_event.hpp>
 #include <WiFiManager.hpp>
+#include <NSPM_version.hpp>
 #include <cmath>
 #include <driver/adc.h>
 #include <esp_adc_cal.h>
@@ -31,6 +32,7 @@ void StatusUpdateManager::init() {
   StatusUpdateManager::_status_report.rssi = 0;
   StatusUpdateManager::_status_report.temperature = 0;
   StatusUpdateManager::_status_report.mac_address = (char *)WiFiManager::mac_string();
+  StatusUpdateManager::_status_report.version = NSPM_VERSION;
   StatusUpdateManager::_status_report.md5_firmware = (char *)ConfigManager::md5_firmware.c_str();
   StatusUpdateManager::_status_report.md5_littlefs = (char *)ConfigManager::md5_data_file.c_str();
   StatusUpdateManager::_status_report.md5_tft_gui = (char *)ConfigManager::md5_gui.c_str();
@@ -82,6 +84,10 @@ void StatusUpdateManager::_send_status_update(void *arg) {
     StatusUpdateManager::_status_report.heap_used_pct = heap_used_pct;
     StatusUpdateManager::_status_report.ip_address = (char *)WiFiManager::ip_string().c_str();
     StatusUpdateManager::_status_report.temperature = StatusUpdateManager::_measured_average_temperature.get();
+    StatusUpdateManager::_status_report.version = NSPM_VERSION;
+    StatusUpdateManager::_status_report.md5_firmware = (char *)ConfigManager::md5_firmware.c_str();
+    StatusUpdateManager::_status_report.md5_littlefs = (char *)ConfigManager::md5_data_file.c_str();
+    StatusUpdateManager::_status_report.md5_tft_gui = (char *)ConfigManager::md5_gui.c_str();
 
     // TODO: Load warnings
     // Send status update

--- a/firmware_espidf/lib/UpdateManager/UpdateManager.cpp
+++ b/firmware_espidf/lib/UpdateManager/UpdateManager.cpp
@@ -472,7 +472,7 @@ void UpdateManager::_mqtt_event_handler(void *arg, esp_event_base_t event_base, 
     if (topic_string.compare(command_topic) == 0) {
       cJSON *json = cJSON_ParseWithLength(event->data, event->data_len);
       if (json == NULL) {
-        ESP_LOGW("UpgradeManager", "Failed to parse payload as JSON.");
+        ESP_LOGW("UpdateManager", "Failed to parse payload as JSON.");
         // Failed to parse as JSON
         return;
       }
@@ -482,7 +482,7 @@ void UpdateManager::_mqtt_event_handler(void *arg, esp_event_base_t event_base, 
         std::string command_string = item->valuestring;
 
         if (command_string.compare("reboot") == 0) { // TODO: Move to some place more fitting.
-          ESP_LOGI("UpgradeManager", "Received command to reboot. Will reboot NSPanel.");
+          ESP_LOGI("UpdateManager", "Received command to reboot. Will reboot NSPanel.");
           esp_restart();
         } else if (command_string.compare("firmware_update") == 0 && UpdateManager::_current_update_task == NULL) {
           xTaskCreatePinnedToCore(UpdateManager::update_firmware, "update_firmware", 8192, NULL, 2, &UpdateManager::_current_update_task, 1);
@@ -492,7 +492,7 @@ void UpdateManager::_mqtt_event_handler(void *arg, esp_event_base_t event_base, 
         } else if (command_string.compare("tft_update") == 0 && UpdateManager::_current_update_task == NULL) {
           xTaskCreatePinnedToCore(UpdateManager::update_gui, "update_gui", 8192, NULL, 2, &UpdateManager::_current_update_task, 1);
         } else {
-          ESP_LOGW("UpgradeManager", "Unknown command: %s", item->valuestring);
+          ESP_LOGW("UpdateManager", "Unknown command: %s", item->valuestring);
         }
       }
 

--- a/firmware_espidf/src/main.cpp
+++ b/firmware_espidf/src/main.cpp
@@ -1,4 +1,4 @@
-// #include <ButtonManager.hpp>
+#include <ButtonManager.hpp>
 #include <ConfigManager.hpp>
 #include <InterfaceManager.hpp>
 #include <LittleFS.hpp>
@@ -123,7 +123,7 @@ extern "C" void app_main() {
   }
 
   // Setup ButtonManager to handle physical buttons and relays
-  // ButtonManager::init();
+  ButtonManager::init();
 
   // Only start managers for actual functionality if MQTT is configured.
   if (!ConfigManager::mqtt_server.empty()) {
@@ -131,7 +131,7 @@ extern "C" void app_main() {
     MqttManager::start(&ConfigManager::mqtt_server, &ConfigManager::mqtt_port, &ConfigManager::mqtt_username, &ConfigManager::mqtt_password);
 
     // Now that we have created the MQTT client we can register callbacks from it, register ButtonManager
-    // ButtonManager::init_mqtt();
+    ButtonManager::init_mqtt();
 
     // MQTT is now setup, enable custom logging through MQTT
     publish_mqtt_log_messages_queue = xQueueCreate(16, sizeof(char *));


### PR DESCRIPTION
this PR has a companion PR in NSPanelManager: https://github.com/vvvrrooomm/NSPanelManager/tree/feat_add_fallback
This adds a fallback mode to the each button action. In case MQTT is not available fallback can be configured to toggle a relays. This basically enables emergency operation if the home automation is disrupted