### PR TITLE
Fix all-rooms mode display not refreshing when status not yet available

### DIFF
--- a/firmware_espidf/lib/Pages/HomePage.cpp
+++ b/firmware_espidf/lib/Pages/HomePage.cpp
@@ -90,13 +90,12 @@ void HomePage::_update_display() {
       return;
     }
   } else if (HomePage::_current_affect_mode == HomePageAffectMode::ALL) {
-    if (RoomManager::get_home_page_status_all_rooms(&status) == ESP_OK) [[likely]] {
-      Nextion::set_component_text(GUI_HOME_PAGE::mode_label_name, "All lights", 100);
-      Nextion::set_component_text(GUI_HOME_PAGE::room_label_name, "All", 100);
-      Nextion::set_component_pic(GUI_HOME_PAGE::button_scenes_name, GUI_HOME_PAGE::button_scenes_all_rooms_pic, 250);
-      Nextion::set_component_pic2(GUI_HOME_PAGE::button_scenes_name, GUI_HOME_PAGE::button_scenes_all_rooms_pic2, 250);
-    } else {
-      ESP_LOGE("HomePage", "Failed to get status object for home page (all rooms). Will abort update.");
+    Nextion::set_component_text(GUI_HOME_PAGE::mode_label_name, "All lights", 100);
+    Nextion::set_component_text(GUI_HOME_PAGE::room_label_name, "All", 100);
+    Nextion::set_component_pic(GUI_HOME_PAGE::button_scenes_name, GUI_HOME_PAGE::button_scenes_all_rooms_pic, 250);
+    Nextion::set_component_pic2(GUI_HOME_PAGE::button_scenes_name, GUI_HOME_PAGE::button_scenes_all_rooms_pic2, 250);
+    if (RoomManager::get_home_page_status_all_rooms(&status) != ESP_OK) [[unlikely]] {
+      ESP_LOGW("HomePage", "All-rooms status not yet available; slider updates deferred until MQTT data arrives.");
       return;
     }
   } else {


### PR DESCRIPTION
## Summary

- In `HomePageAffectMode::ALL`, `_update_display()` wrapped the mode label, room label, and scene button updates inside the `get_home_page_status_all_rooms() == ESP_OK` guard. If the all-rooms status hadn't been received from MQTT yet (e.g. server just restarted), the function returned early and left stale room-mode text on screen — even after the user had successfully switched to global mode.
- Move the label/icon updates unconditionally before the status check; only the slider updates (which need live brightness/color data) are deferred until the MQTT status arrives.

## Test plan

- [ ] Switch from room mode to all-rooms mode on a panel where the all-rooms MQTT retain hasn't been received yet — verify mode label and scene button icon update immediately
- [ ] Confirm sliders update once the all-rooms status arrives
- [ ] Verify normal room-mode display is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)